### PR TITLE
24 multi monitor aware width height

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ CFLAGS+=$(shell pkg-config --cflags libwnck-1.0) $(shell pkg-config --cflags ${L
 LDFLAGS=
 LDFLAGS+=$(shell dpkg-buildflags --get LDFLAGS)
 LDFLAGS+=$(shell pkg-config --libs libwnck-1.0) $(shell pkg-config --libs ${LVER})
-LDFLAGS+=-lX11
+LDFLAGS+=-lX11 -lXrandr
 
 #
 # Setup our sources.

--- a/bindings.c
+++ b/bindings.c
@@ -27,7 +27,7 @@
 #include <gdk/gdk.h>
 #include <gdk/gdkx.h>
 #include <X11/Xatom.h>
-
+#include <X11/extensions/Xrandr.h>
 
 #define WNCK_I_KNOW_THIS_IS_UNSTABLE 1
 #include <libwnck/libwnck.h>
@@ -609,8 +609,21 @@ int lua_readdir(lua_State * L)
  */
 int lua_screen_height(lua_State * L)
 {
-    WnckScreen *screen = wnck_window_get_screen(g_window);
-    lua_pushinteger(L, wnck_screen_get_height(screen));
+    Display *d = gdk_x11_get_default_xdisplay();
+    Window   w = wnck_window_get_xid(g_window);
+    XRRScreenResources *xrrr = XRRGetScreenResources(d, w);
+    XRRCrtcInfo *xrrci;
+    int height = 0;
+    int ncrtc = xrrr->ncrtc;
+    for (int i = 0; i < ncrtc; ++i) {
+        xrrci = XRRGetCrtcInfo(d, xrrr, xrrr->crtcs[i]);
+        if ( xrrci->height > 0 )
+            height = xrrci->height;
+        XRRFreeCrtcInfo(xrrci);
+    }
+    XRRFreeScreenResources(xrrr);
+
+    lua_pushinteger(L, height);
     return 1;
 }
 
@@ -620,8 +633,21 @@ int lua_screen_height(lua_State * L)
  */
 int lua_screen_width(lua_State * L)
 {
-    WnckScreen *screen = wnck_window_get_screen(g_window);
-    lua_pushinteger(L, wnck_screen_get_width(screen));
+    Display *d = gdk_x11_get_default_xdisplay();
+    Window   w = wnck_window_get_xid(g_window);
+    XRRScreenResources *xrrr = XRRGetScreenResources(d, w);
+    XRRCrtcInfo *xrrci;
+    int width = 0;
+    int ncrtc = xrrr->ncrtc;
+    for (int i = 0; i < ncrtc; ++i) {
+        xrrci = XRRGetCrtcInfo(d, xrrr, xrrr->crtcs[i]);
+        if ( xrrci->width > 0 )
+            width = xrrci->width;
+        XRRFreeCrtcInfo(xrrci);
+    }
+    XRRFreeScreenResources(xrrr);
+
+    lua_pushinteger(L, width);
     return 1;
 }
 


### PR DESCRIPTION
This pull-request updates the handling of the `screen_width()` and `screen_height()` functions to return the size of the screen the given window is located upon.

i.e. It is designed to cover the case where you have a multi-monitor setup, with each screen having different dimensions.

It will close #24 once merged - I hope.  Awaiting explicit confirmation from the bug-reporter :)