### PR TITLE
Add Option to Prevent Window Focus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BASE=kpie
 #
 # The version of Lua we build against.
 #
-LUA_VERSION=5.1
+LUA_VERSION=52
 
 #
 # Magic to guess the Lua library versions.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BASE=kpie
 #
 # The version of Lua we build against.
 #
-LUA_VERSION=52
+LUA_VERSION=5.1
 
 #
 # Magic to guess the Lua library versions.

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,42 @@
+pkgname=kpie-git
+_gitname=kpie
+pkgver=
+pkgrel=1
+pkgdesc='Window rules daemon similar to devilspie with active development'
+arch=('x86_64')
+url="https://github.com/skx/kpie"
+license=('GPL3')
+depends=('glib2' 'gtk2' 'lua52' 'libwnck' 'xorgproto' 'libx11')
+makedepends=('git')
+provides=('kpie')
+conflicts=('kpie')
+source=('git+${url}.git')
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_gitname"
+  git describe --long --tags | sed -E 's/([^-]*-g)/r\1/;s/-/./g'
+}
+    
+prepare() {
+  cd "$srcdir/$_gitname"
+  # tweak Makefile
+  sed -i 's/^LUA_VERSION=5.1/LUA_VERSION=52/' Makefile
+  sed -i 's/^LDFLAGS.*dpkg-buildflags.*//' Makefile
+}
+
+build() {
+  cd "$srcdir/$_gitname"
+  make
+}
+ 
+package() {
+  cd "$srcdir/$_gitname"
+
+  mkdir -p "$pkgdir/usr/bin/"
+  mkdir -p "$pkgdir/usr/share/$_gitname/samples"
+
+  install -m755 "$srcdir/$_gitname"/kpie "$pkgdir/usr/bin"
+  install -m644 "$srcdir/$_gitname"/{README,FAQ}.md "$pkgdir/usr/share/$_gitname"
+  install -m644 "$srcdir/$_gitname/samples"/* "$pkgdir/usr/share/$_gitname/samples"
+}

--- a/bindings.c
+++ b/bindings.c
@@ -154,6 +154,7 @@ void init_lua(int _debug, const char *config_file)
     lua_register(g_L, "maximize_horizontally", lua_maximize_horizontally);
     lua_register(g_L, "maximize_vertically", lua_maximize_vertically);
     lua_register(g_L, "minimize", lua_minimize);
+    lua_register(g_L, "nofocus", lua_nofocus);
     lua_register(g_L, "pin", lua_pin);
     lua_register(g_L, "pointer", lua_pointer);
     lua_register(g_L, "readdir", lua_readdir);
@@ -523,6 +524,21 @@ int lua_minimize(lua_State * L)
     UNUSED(L);
     debug("minimizing window");
     wnck_window_minimize(g_window);
+    return 0;
+}
+
+
+/**
+ * Prevent focus for the current window
+ */
+int lua_nofocus(lua_State * L)
+{
+    /* Variable setup */
+    GdkDisplay *display = NULL;
+    Window   w = wnck_window_get_xid(g_window);
+    display = gdk_display_get_default();
+
+    XSetWMHints(display, w, input = False);
     return 0;
 }
 

--- a/bindings.c
+++ b/bindings.c
@@ -533,12 +533,19 @@ int lua_minimize(lua_State * L)
  */
 int lua_nofocus(lua_State * L)
 {
+#define	InputHint	(1L << 0)
+    XWMHints* inputTOG = XAllocWMHints();
+    if (!inputTOG) {
+    fprintf(stderr, "XAllocWMHints - out of memory\n");
+    exit(1);
+    }
     /* Variable setup */
-    GdkDisplay *display = NULL;
-    Window   w = wnck_window_get_xid(g_window);
-    display = gdk_display_get_default();
-
-    XSetWMHints(display, w, input = False);
+    display = gdk_x11_get_default_xdisplay();
+    w = wnck_window_get_xid(g_window);
+    inputTOG->flags = InputHint;
+    inputTOG->input = False;
+    XSetWMHints(d, w, inputTOG);
+    XFree(inputTOG);
     return 0;
 }
 

--- a/bindings.h
+++ b/bindings.h
@@ -84,6 +84,7 @@ int lua_maximize(lua_State * L);
 int lua_maximize_horizontally(lua_State * L);
 int lua_maximize_vertically(lua_State * L);
 int lua_minimize(lua_State * L);
+int lua_nofocus(lua_State * L);
 int lua_pin(lua_State * L);
 int lua_pointer(lua_State *L);
 int lua_readdir(lua_State * L);


### PR DESCRIPTION
I've sought a method to apply per application window focus rules for too long now. While easy to accomplish in compiz, openbox, and KDE, finding something for XFCE has been exceptionally hard. devilspie2 lacked this feature & devilspie doesn't seem to have an obvious way to prevent input from being given to a window.

The reason is mainly for Steam Keyboard compatibility. Without this as a rule, usage of Steam's on screen keyboard becomes cumbersome, having to select each input field while holding the Steam button before being able to type because the Steam Keyboard chokes on input strokes. Steam will freeze & you will be having a bad time. Preventing input focus should solve this issue.

This patch is by no means complete. I've never had experience in this syntax, so I know in its current state, this is unusable. With a little polish, this would be ready. Here's some references you might find useful:
https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/wm-hints.html
https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/XSetWMHints.html
https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.7

As a bonus, I threw in the PKGBUILD some arch member decided to put up here not long ago. It seems to have had a few variable errors which I believe have been sorted out.

Lastly, the readme should probably be updated as autoreconf --install doesn't work, nor does ./configure. This program only builds with make alone (at least on my setup).